### PR TITLE
Chat network logic (backend)

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "start:server": "npx ts-node --compiler-options=\"{\\\"module\\\": \\\"commonjs\\\"}\" server",
     "start:server:watch": "nodemon --config \"./nodemon.json\"/",
     "//2": "PRODUCTION",
-    "prestart": "[ ! -d 'build' ] && echo 'Missing production build. Run `npm run build` or did you mean to run `npm run start:app` and `npm run start:server` for development mode?' && exit 1",
+    "prestart": "[ ! -d 'build' ] && echo 'Missing production build. Run `npm run build` or did you mean to run `npm run start:app` and `npm run start:server` for development mode?' && exit 1 || exit 0",
     "start": "node -r esm build/server",
     "//3": "BUILD",
     "build:app": "react-scripts build",

--- a/server/core/Room.ts
+++ b/server/core/Room.ts
@@ -7,13 +7,15 @@ import Game from './Game';
 import BGIOWrapper from './BGIOWrapper';
 import IORoomServer from '../io/IORoomServer';
 import { People, Player, AnyFunction } from './types';
+import { stringify } from 'querystring';
 
 export default class Room {
   logger: log4js.Logger;
+  id: string | undefined;
   spectators: People;
   players: People;
+  chat: { userID: string, modified: boolean, message: string }[];
   game: Game | BGIOWrapper;
-  id: string | undefined;
 
   constructor(gameId: string) {
     this.logger = log4js.getLogger('Room#undefined');
@@ -21,6 +23,7 @@ export default class Room {
 
     this.spectators = {};
     this.players = {};
+    this.chat = [];
 
     switch (gameId) {
       case 'the-resistance-avalon':
@@ -65,6 +68,7 @@ export default class Room {
       key: this.key,
       players: this.players,
       spectators: this.spectators,
+      chat: this.chat,
       ...this.game.ctx
     };
   }
@@ -76,7 +80,8 @@ export default class Room {
   contextChangeListener(fn: AnyFunction, callback: AnyFunction) {
     const ctx = {
       spectators: this.spectators,
-      players: this.players
+      players: this.players,
+      chat: this.chat
     };
 
     const [err, nextCtx, changes] = errorListener(ctx, fn);
@@ -84,6 +89,7 @@ export default class Room {
     if (err === undefined) {
       this.spectators = nextCtx.spectators;
       this.players = nextCtx.players;
+      this.chat = nextCtx.chat;
       return callback(null, changes);
     } else {
       return callback(err);
@@ -395,4 +401,17 @@ export default class Room {
   //     }
   //   });
   // }
+
+  editChat(id: string, mid: number | undefined | null, message: string, callback: AnyFunction) {
+    if (mid != null && (mid < 0 || mid >= this.chat.length || this.chat[mid].userID !== id)) {
+      return callback('Invalid message to edit');
+    }
+    this.contextChangeListener(ctx => {
+      if (mid == null) {
+        ctx.chat.push({ userID: id, modified: false, message });
+      } else {
+        ctx.chat[mid] = { ...ctx.chat[mid], modified: true, message };
+      }
+    }, callback);
+  }
 }

--- a/server/io/IORoomServer.ts
+++ b/server/io/IORoomServer.ts
@@ -29,6 +29,7 @@ export default class IORoomServer {
       this.attachSettingsListener(client);
       this.attachStartListener(client);
       // this.attachGameListener(client);
+      this.attachChatListener(client);
     });
   }
 
@@ -301,4 +302,28 @@ export default class IORoomServer {
   //     });
   //   });
   // }
+
+  attachChatListener(client) {
+    client.on('chat', (message, messageID?) => {
+      const key = client.roomKey;
+      if (messageID == null) {
+        logger.trace(`User (${client.userId}) sending chat in room (${key}): ${JSON.stringify(message)}`);
+      } else {
+        logger.trace(`User (${client.userId}) modifying chat (${messageID}) in room (${key}): ${JSON.stringify(message)}`);
+      }
+      const room = this.roomManager.getRoom(key);
+      if (room == null) {
+        logger.error(`User (${client.userId}) chatting in room (${key}) failed: Room does not exist`);
+        client.emit('message', { status: 'error', text: 'Room does not exist' });
+        return client.disconnect();
+      }
+      room.editChat(client.userId, messageID, message, (err, ctxChanges) => {
+        if (err) {
+          client.emit('message', { status: 'error', text: err });
+        } else {
+          this.ioRoomServer.to(key).emit('changes', ctxChanges);
+        }
+      });
+    });
+  }
 }


### PR DESCRIPTION
Client should emit a 'chat' event with the following parameters:
message - message to send
id - id of message to modify (0-based index), if null will append message to array of messages.

(Don't worry about the edit message stuff, I just added the support in case we want to allow editing messages in the future)

example:
```
import { useContext } from 'react';
const [client] = useContext(ClientContext);

client.emit('chat', 'Hello, world!');
```

For retrieving the chat messages, the room object will contain room.ctx.chat array.
The array looks as follows:
`chat: { userID: string, modified: boolean, message: string }[];`
The messages will have to be mapped such that the userID is mapped to the user names
e.g: `room.ctx.chat.map(c => {name: room.ctx.players[c.userID].name, message: c.message})`